### PR TITLE
Fix undefined array key warning on PHP 8

### DIFF
--- a/action.php
+++ b/action.php
@@ -22,7 +22,7 @@ class action_plugin_pagehere extends DokuWiki_Action_Plugin {
     }
 
     public function handle_dokuwiki_started(Doku_Event &$event, $param) {
-        if(!$_REQUEST['pagehere']) return;
+        if(!($_REQUEST['pagehere'] ?? false)) return;
 
         global $ID;
         global $conf;


### PR DESCRIPTION
Dokuwiki displays 

Warning: Undefined array key "pagehere" in /path/to/dokuwiki/lib/plugins/pagehere/action.php on line 25
