### PR TITLE
Add space between input field an button

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,7 @@
 form.page_here {
     display: inline;
 }
+
+.plugin_pagehere .btn {
+    margin-left: 5px;
+}


### PR DESCRIPTION
By default the button slightly overlaps the input field - especially when the field is focused in the default theme.